### PR TITLE
improv(search): improved search performance by memoizing the fuse index

### DIFF
--- a/app/components/content/search-bar.tsx
+++ b/app/components/content/search-bar.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useParams } from "@remix-run/react";
 import Fuse, { FuseResult, FuseResultMatch } from "fuse.js";
 import { Search, X } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "~/contents/i18n/translator";
 import { getAppUrl } from "~/contents/navigation/get-url";
 import { useAppConfig } from "~/routes/($lang)";
@@ -15,6 +15,14 @@ export type SearchItem = {
   content: string;
   slug: string;
 };
+
+const fuseOptions = {
+  keys: ["content", "title"],
+  includeMatches: true,
+  threshold: 0.3,
+  minMatchCharLength: 3,
+  distance: 100000,
+}
 
 export function SearchBar({
   items,
@@ -30,17 +38,14 @@ export function SearchBar({
   const { DEFAULT_LANGUAGE, LATEST_VERSION } = useAppConfig();
   const [searchQuery, setSearchQuery] = useState<string>("");
   const params = useParams();
+  const fuseIndex = useMemo(() => Fuse.createIndex(fuseOptions.keys, items), [items]);
+  const fuse = useMemo(() => new Fuse(items, fuseOptions, fuseIndex), [fuseIndex, items]);
+
   const onSearch = (query: string) => {
     setSearchQuery(query);
-    const fuse = new Fuse(items, {
-      keys: ["content", "title"],
-      includeMatches: true,
-      threshold: 0.3,
-      minMatchCharLength: 3,
-      distance: 100000,
-    });
 
     const searchResults = fuse.search(query);
+
     setResults(searchResults);
   };
 


### PR DESCRIPTION
I was checking out the code for the search bar whenI realized that the items were being indexed at every user keystroke. This is not needed and will likely cause performance issues when dealing with a big quantity of documents, so i memoized them.

**Before**
![image](https://github.com/user-attachments/assets/cbc46049-0742-4ecf-8199-dcea2981319d)

**After**
![image](https://github.com/user-attachments/assets/004e4d71-8a6a-45ef-8f58-87591e240c20)
